### PR TITLE
[ci skip] [skip ci] ***NO_CI*** Update maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @conda-forge/r @jdblischak
+* @conda-forge/r

--- a/README.md
+++ b/README.md
@@ -116,5 +116,4 @@ Feedstock Maintainers
 =====================
 
 * [@conda-forge/r](https://github.com/conda-forge/r/)
-* [@jdblischak](https://github.com/jdblischak/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,4 +46,3 @@ about:
 extra:
   recipe-maintainers:
     - conda-forge/r
-    - jdblischak


### PR DESCRIPTION

Remove individually listed maintainers that are members of the conda-forge/r team

Followed a similar strategy from the docs for updating the maintainers. Unfortunately it doesn't appear possible to skip the CI jobs in the PR itself, even the example PR had jobs run

https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list
